### PR TITLE
Refactor yt-dlp flag construction to prevent duplicate flags

### DIFF
--- a/internal/builder/ytdlp_builder.go
+++ b/internal/builder/ytdlp_builder.go
@@ -8,9 +8,39 @@ import (
 	"strings"
 )
 
+type YTDLPState struct {
+	Newline            bool
+	Update             bool
+	IgnoreErrors       bool
+	WriteSubtitles     bool
+	WriteAutoSubtitles bool
+
+	Format                string
+	ProgressTemplate      string
+	HasProgressTemplate   bool
+	DownloadPath          string
+	HasDownloadPath       bool
+	URL                   string
+	HasURL                bool
+	Cookies               string
+	HasCookies            bool
+	CookiesFromBrowser    string
+	HasCookiesFromBrowser bool
+	JsRuntimes            []string
+	ExtractorArgs         []string
+	DownloadSections      []string
+	SleepSubtitles        int
+	HasSleepSubtitles     bool
+	SubtitlesFormat       bool
+	SubtitlesLanguages    []string
+	SafeFilenames         bool
+	Playlist              domain.PlaylistSelection
+	HasPlaylist           bool
+}
+
 type YTDLPBuilder struct {
-	args      []string
 	ytdlpPath string
+	state     YTDLPState
 }
 
 func NewYTDLPBuilder() *YTDLPBuilder {
@@ -49,13 +79,14 @@ func (y *YTDLPBuilder) GetYtDlpPath() string {
 
 // "[byto:title] %(info.title)s [byto:downloaded_bytes] %(progress.downloaded_bytes)d [byto:total_bytes] %(progress.total_bytes)d"
 func (y *YTDLPBuilder) ProgressTemplate(template string) *YTDLPBuilder {
-	y.args = append(y.args, "--progress-template", template)
+	y.state.ProgressTemplate = template
+	y.state.HasProgressTemplate = true
 	return y
 }
 
 // Newline forces a newline character at the end of each progress line
 func (y *YTDLPBuilder) Newline() *YTDLPBuilder {
-	y.args = append(y.args, "--newline")
+	y.state.Newline = true
 	return y
 }
 
@@ -65,52 +96,58 @@ func (y *YTDLPBuilder) Video(quality domain.VideoQuality) *YTDLPBuilder {
 	// 1. Try best video up to X height + best audio
 	// 2. Fall back to combined best up to X height
 	// 3. Fall back to absolute best available
+
 	switch quality {
 	case domain.Quality360p:
-		y.args = append(y.args, "-f", "bestvideo[height<=360]+bestaudio/best[height<=360]/best")
+		y.state.Format = "bestvideo[height<=360]+bestaudio/best[height<=360]/best"
+
 	case domain.Quality480p:
-		y.args = append(y.args, "-f", "bestvideo[height<=480]+bestaudio/best[height<=480]/best")
+		y.state.Format = "bestvideo[height<=480]+bestaudio/best[height<=480]/best"
+
 	case domain.Quality720p:
-		y.args = append(y.args, "-f", "bestvideo[height<=720]+bestaudio/best[height<=720]/best")
+		y.state.Format = "bestvideo[height<=720]+bestaudio/best[height<=720]/best"
+
 	case domain.Quality1080p:
-		y.args = append(y.args, "-f", "bestvideo[height<=1080]+bestaudio/best[height<=1080]/best")
+		y.state.Format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]/best"
+
 	case domain.Quality1440p:
-		y.args = append(y.args, "-f", "bestvideo[height<=1440]+bestaudio/best[height<=1440]/best")
+		y.state.Format = "bestvideo[height<=1440]+bestaudio/best[height<=1440]/best"
+
 	case domain.Quality2160p:
-		y.args = append(y.args, "-f", "bestvideo[height<=2160]+bestaudio/best[height<=2160]/best")
+		y.state.Format = "bestvideo[height<=2160]+bestaudio/best[height<=2160]/best"
+
 	default:
-		y.args = append(y.args, "-f", "bestvideo+bestaudio/best")
+		y.state.Format = "bestvideo+bestaudio/best"
 	}
+
 	return y
 }
 
 func (y *YTDLPBuilder) Audio() *YTDLPBuilder {
-	y.args = append(y.args, "-f", "bestaudio/best")
+	y.state.Format = "bestaudio/best"
 	return y
 }
 
 func (y *YTDLPBuilder) DownloadPath(path string) *YTDLPBuilder {
-	y.args = append(y.args, "-o", path+"/%(title).100s.%(ext)s")
+	y.state.DownloadPath = path
+	y.state.HasDownloadPath = true
 	return y
 }
 
 // SafeFilenames adds platform-appropriate filename restrictions
 func (y *YTDLPBuilder) SafeFilenames() *YTDLPBuilder {
-	if runtime.GOOS == "windows" {
-		y.args = append(y.args, "--windows-filenames")
-	} else {
-		y.args = append(y.args, "--restrict-filenames")
-	}
+	y.state.SafeFilenames = true
 	return y
 }
 
 func (y *YTDLPBuilder) URL(url string) *YTDLPBuilder {
-	y.args = append(y.args, url)
+	y.state.URL = url
+	y.state.HasURL = true
 	return y
 }
 
 func (y *YTDLPBuilder) Update() *YTDLPBuilder {
-	y.args = append(y.args, "--update")
+	y.state.Update = true
 	return y
 }
 
@@ -118,72 +155,188 @@ func (y *YTDLPBuilder) Playlist(playlist domain.PlaylistSelection) *YTDLPBuilder
 	if err := playlist.Validate(); err != nil {
 		return y
 	}
-	switch playlist.Type {
-	case domain.SelectionRange:
-		y.args = append(y.args, "--playlist-items", fmt.Sprintf("%d-%d", playlist.StartIndex, playlist.EndIndex))
-	case domain.SelectionItems:
-		y.args = append(y.args, "--playlist-items", playlist.Items)
-	}
+
+	y.state.Playlist = playlist
+	y.state.HasPlaylist = true
 	return y
 }
 
 func (y *YTDLPBuilder) Cookies(path string) *YTDLPBuilder {
-	y.args = append(y.args, "--cookies", path)
+	y.state.Cookies = path
+	y.state.HasCookies = true
 	return y
 }
 
 func (y *YTDLPBuilder) CookiesFromBrowser(browser string) *YTDLPBuilder {
-	y.args = append(y.args, "--cookies-from-browser", browser)
+	y.state.CookiesFromBrowser = browser
+	y.state.HasCookiesFromBrowser = true
 	return y
 }
 
 func (y *YTDLPBuilder) JsRuntimes(jsRuntime string) *YTDLPBuilder {
-	y.args = append(y.args, "--js-runtimes", jsRuntime)
+	y.state.JsRuntimes = append(y.state.JsRuntimes, jsRuntime)
 	return y
 }
 
 func (y *YTDLPBuilder) ExtractorArgs(args string) *YTDLPBuilder {
-	y.args = append(y.args, "--extractor-args", args)
+	y.state.ExtractorArgs = append(y.state.ExtractorArgs, args)
 	return y
 }
 
 func (y *YTDLPBuilder) DownloadSection(timerange domain.TimeRange) *YTDLPBuilder {
-	y.args = append(y.args, "--download-sections", fmt.Sprintf("*%s-%s", timerange.Start, timerange.End))
+	y.state.DownloadSections = append(
+		y.state.DownloadSections,
+		fmt.Sprintf("*%s-%s", timerange.Start, timerange.End),
+	)
+
 	return y
 }
 
 func (y *YTDLPBuilder) IgnoreErrors() *YTDLPBuilder {
-	y.args = append(y.args, "--ignore-errors")
+	y.state.IgnoreErrors = true
 	return y
 }
 
 func (y *YTDLPBuilder) WriteSubtitles() *YTDLPBuilder {
-	y.args = append(y.args, "--write-subs")
+	y.state.WriteSubtitles = true
 	return y
 }
 
 func (y *YTDLPBuilder) WriteAutoSubtitles() *YTDLPBuilder {
-	y.args = append(y.args, "--write-auto-subs")
+	y.state.WriteAutoSubtitles = true
 	return y
 }
 
 func (y *YTDLPBuilder) SleepSubtitles(seconds int) *YTDLPBuilder {
-	y.args = append(y.args, "--sleep-subtitles", fmt.Sprintf("%d", seconds))
+	y.state.SleepSubtitles = seconds
+	y.state.HasSleepSubtitles = true
 	return y
 }
 
 func (y *YTDLPBuilder) SubtitlesFormat() *YTDLPBuilder {
-	y.args = append(y.args, "--sub-format", "srt/vtt/best")
+	y.state.SubtitlesFormat = true
 	return y
 }
 
 func (y *YTDLPBuilder) SubtitlesLanguages(languageCodes []string) *YTDLPBuilder {
 	if len(languageCodes) > 0 {
-		y.args = append(y.args, "--sub-langs", strings.Join(languageCodes, ","))
+		y.state.SubtitlesLanguages = languageCodes
 	}
 	return y
 }
 
 func (y *YTDLPBuilder) Build() []string {
-	return y.args
+	var args []string
+
+	if y.state.IgnoreErrors {
+		args = append(args, "--ignore-errors")
+	}
+
+	if y.state.Newline {
+		args = append(args, "--newline")
+	}
+
+	if y.state.Update {
+		args = append(args, "--update")
+	}
+
+	if y.state.WriteSubtitles {
+		args = append(args, "--write-subs")
+	}
+
+	if y.state.WriteAutoSubtitles {
+		args = append(args, "--write-auto-subs")
+	}
+
+	if y.state.Format != "" {
+		args = append(args, "-f", y.state.Format)
+	}
+
+	if y.state.HasCookies {
+		args = append(args, "--cookies", y.state.Cookies)
+	}
+
+	if y.state.HasCookiesFromBrowser {
+		args = append(args, "--cookies-from-browser", y.state.CookiesFromBrowser)
+	}
+
+	if y.state.HasPlaylist {
+		switch y.state.Playlist.Type {
+		case domain.SelectionRange:
+			args = append(
+				args,
+				"--playlist-items",
+				fmt.Sprintf(
+					"%d-%d",
+					y.state.Playlist.StartIndex,
+					y.state.Playlist.EndIndex,
+				),
+			)
+
+		case domain.SelectionItems:
+			args = append(
+				args,
+				"--playlist-items",
+				y.state.Playlist.Items,
+			)
+		}
+	}
+
+	if y.state.HasURL {
+		args = append(args, y.state.URL)
+	}
+
+	if y.state.HasDownloadPath {
+		args = append(
+			args,
+			"-o",
+			y.state.DownloadPath+"/%(title).100s.%(ext)s",
+		)
+	}
+
+	if y.state.HasProgressTemplate {
+		args = append(args, "--progress-template", y.state.ProgressTemplate)
+	}
+
+	for _, jsRuntime := range y.state.JsRuntimes {
+		args = append(args, "--js-runtimes", jsRuntime)
+	}
+
+	for _, extractorArgs := range y.state.ExtractorArgs {
+		args = append(args, "--extractor-args", extractorArgs)
+	}
+
+	for _, section := range y.state.DownloadSections {
+		args = append(args, "--download-sections", section)
+	}
+
+	if y.state.HasSleepSubtitles {
+		args = append(
+			args,
+			"--sleep-subtitles",
+			fmt.Sprintf("%d", y.state.SleepSubtitles),
+		)
+	}
+
+	if y.state.SubtitlesFormat {
+		args = append(args, "--sub-format", "srt/vtt/best")
+	}
+
+	if len(y.state.SubtitlesLanguages) > 0 {
+		args = append(
+			args,
+			"--sub-langs",
+			strings.Join(y.state.SubtitlesLanguages, ","),
+		)
+	}
+
+	if y.state.SafeFilenames {
+		if runtime.GOOS == "windows" {
+			args = append(args, "--windows-filenames")
+		} else {
+			args = append(args, "--restrict-filenames")
+		}
+	}
+
+	return args
 }

--- a/internal/builder/ytdlp_builder_test.go
+++ b/internal/builder/ytdlp_builder_test.go
@@ -5,6 +5,7 @@ import (
 	"byto/internal/deps"
 	"byto/internal/domain"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -738,5 +739,187 @@ func TestCookiesFromBrowser_ChainsWithOtherMethods(t *testing.T) {
 	}
 	if args[4] != "https://example.com/video" {
 		t.Errorf("expected URL at index 4, got %q", args[4])
+	}
+}
+func TestBooleanFlagsAreNotDuplicated(t *testing.T) {
+	b := &builder.YTDLPBuilder{}
+
+	b.Newline().Newline()
+	b.Update().Update()
+	b.IgnoreErrors().IgnoreErrors()
+	b.WriteSubtitles().WriteSubtitles()
+	b.WriteAutoSubtitles().WriteAutoSubtitles()
+
+	args := b.Build()
+
+	flags := []string{
+		"--newline",
+		"--update",
+		"--ignore-errors",
+		"--write-subs",
+		"--write-auto-subs",
+	}
+
+	for _, flag := range flags {
+		count := 0
+
+		for _, arg := range args {
+			if arg == flag {
+				count++
+			}
+		}
+
+		if count != 1 {
+			t.Errorf("expected %s exactly once, got %d times: %v", flag, count, args)
+		}
+	}
+}
+
+func TestFormatLastCallWinsWithoutDuplication(t *testing.T) {
+	b := &builder.YTDLPBuilder{}
+
+	b.Audio()
+	b.Video(domain.Quality720p)
+
+	args := b.Build()
+
+	count := 0
+
+	for _, arg := range args {
+		if arg == "-f" {
+			count++
+		}
+	}
+
+	if count != 1 {
+		t.Errorf("expected -f exactly once, got %d times: %v", count, args)
+	}
+
+	expectedFormat := "bestvideo[height<=720]+bestaudio/best[height<=720]/best"
+
+	if args[len(args)-1] != expectedFormat {
+		t.Errorf("expected format %q, got %q", expectedFormat, args[len(args)-1])
+	}
+}
+
+func TestSingleValueFlagsAreNotDuplicated(t *testing.T) {
+	b := &builder.YTDLPBuilder{}
+
+	b.Cookies("first.txt")
+	b.Cookies("second.txt")
+
+	b.DownloadPath("/first")
+	b.DownloadPath("/second")
+
+	args := b.Build()
+
+	cookiesCount := 0
+	outputCount := 0
+
+	for _, arg := range args {
+		switch arg {
+		case "--cookies":
+			cookiesCount++
+		case "-o":
+			outputCount++
+		}
+	}
+
+	if cookiesCount != 1 {
+		t.Errorf("expected --cookies once, got %d: %v", cookiesCount, args)
+	}
+
+	if outputCount != 1 {
+		t.Errorf("expected -o once, got %d: %v", outputCount, args)
+	}
+}
+
+func TestBuildHasDeterministicOrder(t *testing.T) {
+	b1 := &builder.YTDLPBuilder{}
+	b1.
+		Video(domain.Quality720p).
+		Cookies("/tmp/cookies.txt").
+		DownloadPath("/tmp").
+		Newline().
+		URL("https://example.com/video")
+
+	b2 := &builder.YTDLPBuilder{}
+	b2.
+		URL("https://example.com/video").
+		Newline().
+		DownloadPath("/tmp").
+		Cookies("/tmp/cookies.txt").
+		Video(domain.Quality720p)
+
+	args1 := b1.Build()
+	args2 := b2.Build()
+
+	if !reflect.DeepEqual(args1, args2) {
+		t.Errorf(
+			"expected deterministic argument order\nfirst:  %v\nsecond: %v",
+			args1,
+			args2,
+		)
+	}
+}
+
+func TestJsRuntimesPreservesRepeatedValues(t *testing.T) {
+	b := &builder.YTDLPBuilder{}
+
+	b.JsRuntimes("deno:/path/to/deno")
+	b.JsRuntimes("node:/path/to/node")
+
+	args := b.Build()
+
+	expected := []string{
+		"--js-runtimes", "deno:/path/to/deno",
+		"--js-runtimes", "node:/path/to/node",
+	}
+
+	if !reflect.DeepEqual(args, expected) {
+		t.Errorf("expected %v, got %v", expected, args)
+	}
+}
+
+func TestExtractorArgsPreservesRepeatedValues(t *testing.T) {
+	b := &builder.YTDLPBuilder{}
+
+	b.ExtractorArgs("youtube:player_client=web")
+	b.ExtractorArgs("tiktok:api_hostname=example")
+
+	args := b.Build()
+
+	expected := []string{
+		"--extractor-args", "youtube:player_client=web",
+		"--extractor-args", "tiktok:api_hostname=example",
+	}
+
+	if !reflect.DeepEqual(args, expected) {
+		t.Errorf("expected %v, got %v", expected, args)
+	}
+}
+
+func TestDownloadSectionPreservesRepeatedValues(t *testing.T) {
+	b := &builder.YTDLPBuilder{}
+
+	b.DownloadSection(domain.TimeRange{
+		Start: "00:10",
+		End:   "00:20",
+	})
+
+	b.DownloadSection(domain.TimeRange{
+		Start: "01:00",
+		End:   "01:30",
+	})
+
+	args := b.Build()
+
+	expected := []string{
+		"--download-sections", "*00:10-00:20",
+		"--download-sections", "*01:00-01:30",
+	}
+
+	if !reflect.DeepEqual(args, expected) {
+		t.Errorf("expected %v, got %v", expected, args)
 	}
 }


### PR DESCRIPTION
Closes #54

Refactored the yt-dlp command construction to use a typed state before building the final arguments.

Single-value and boolean flags are now rendered once, while repeatable options like JS runtimes, extractor args, and download sections can still have multiple values.

I also added tests for duplicate flags, format precedence, deterministic argument ordering, and repeatable options.

`go test ./...` passes.